### PR TITLE
Adds additional FormattedCredentials packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ In some cases the library being used to connect to a service wants its credentia
 
 This library comes with a few formatters out of the box:
 
+* `amqp`: produces the connection string for using the AMPQ library to connect to RabbitMQ.
+* `gomemcache`: produces a connection string for connecting to Memcached with the gomemcache library.
+* `libpq`: produces the `lib/pq` library connection string for PostgreSQL.
+* `mongo`: produces the connection string for using MongoDB's `mongo-driver` for Go.
 * `sqldsn`: produces an SQL connection string appropriate for use with many common Go database tools.
 
 A formatter package can be used in your application by importing it

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ This library comes with a few formatters out of the box:
 
 * `amqp`: produces the connection string for using the AMPQ library to connect to RabbitMQ.
 * `gomemcache`: produces a connection string for connecting to Memcached with the gomemcache library.
+* `gosolr`: returns a `SolrCredentials` struct that contains two strings for using the `go-solr` library: a connection url and the collection name.
 * `libpq`: produces the `lib/pq` library connection string for PostgreSQL.
 * `mongo`: produces the connection string for using MongoDB's `mongo-driver` for Go.
 * `sqldsn`: produces an SQL connection string appropriate for use with many common Go database tools.

--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ In some cases the library being used to connect to a service wants its credentia
 
 This library comes with a few formatters out of the box:
 
-* `amqp`: produces the connection string for using the AMPQ library to connect to RabbitMQ.
-* `gomemcache`: produces a connection string for connecting to Memcached with the gomemcache library.
-* `gosolr`: produces a connection string that includes the full collection path for using the `go-solr` library to connect to Solr.
-* `libpq`: produces the `lib/pq` library connection string for PostgreSQL.
-* `mongo`: produces the connection string for using MongoDB's `mongo-driver` for Go.
-* `sqldsn`: produces an SQL connection string appropriate for use with many common Go database tools.
+* `amqp`: produces the connection string for using the [AMPQ library](https://github.com/streadway/amqp) to connect to RabbitMQ.
+* `gomemcache`: produces a connection string for connecting to Memcached with the [gomemcache library](https://github.com/bradfitz/gomemcache).
+* `gosolr`: produces a connection string that includes the full collection path for using the [`go-solr` library](https://github.com/rtt/Go-Solr) to connect to Solr.
+* `libpq`: produces the [`lib/pq` library](https://github.com/lib/pq) connection string for PostgreSQL.
+* `mongo`: produces the connection string for using MongoDB's [`mongo-driver`](https://github.com/mongodb/mongo-go-driver) for Go.
+* `sqldsn`: produces an SQL connection string appropriate for use with many common Go database tools, including the [go-sql-driver](https://github.com/go-sql-driver/mysql).
 
 A formatter package can be used in your application by importing it
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ This library comes with a few formatters out of the box:
 
 * `amqp`: produces the connection string for using the AMPQ library to connect to RabbitMQ.
 * `gomemcache`: produces a connection string for connecting to Memcached with the gomemcache library.
-* `gosolr`: returns a `SolrCredentials` struct that contains two strings for using the `go-solr` library: a connection url and the collection name.
+* `gosolr`: produces a connection string that includes the full collection path for using the `go-solr` library to connect to Solr.
 * `libpq`: produces the `lib/pq` library connection string for PostgreSQL.
 * `mongo`: produces the connection string for using MongoDB's `mongo-driver` for Go.
 * `sqldsn`: produces an SQL connection string appropriate for use with many common Go database tools.

--- a/amqp/amqp.go
+++ b/amqp/amqp.go
@@ -1,4 +1,4 @@
-package sqldsn
+package amqp
 
 import (
   "fmt"

--- a/amqp/amqp.go
+++ b/amqp/amqp.go
@@ -1,0 +1,13 @@
+package sqldsn
+
+import (
+  "fmt"
+  psh "github.com/platformsh/config-reader-go/v2"
+)
+
+// AMQP requires a specfic connection string to connect to PostgreSQL.
+func FormattedCredentials(creds psh.Credential) (string, error) {
+  formatted := fmt.Sprintf("%s://%s:%s@%s:%d/", creds.Scheme, creds.Username,
+    creds.Password, creds.Host, creds.Port)
+  return formatted, nil
+}

--- a/amqp/amqp.go
+++ b/amqp/amqp.go
@@ -5,9 +5,8 @@ import (
   psh "github.com/platformsh/config-reader-go/v2"
 )
 
-// AMQP requires a specfic connection string to connect to PostgreSQL.
+// AMQP requires a specfic connection string to connect to RabbitMQ.
 func FormattedCredentials(creds psh.Credential) (string, error) {
-  formatted := fmt.Sprintf("%s://%s:%s@%s:%d/", creds.Scheme, creds.Username,
-    creds.Password, creds.Host, creds.Port)
+  formatted := fmt.Sprintf("%s://%s:%s@%s:%d/", creds.Scheme, creds.Username, creds.Password, creds.Host, creds.Port)
   return formatted, nil
 }

--- a/amqp/amqp_test.go
+++ b/amqp/amqp_test.go
@@ -1,4 +1,4 @@
-package sqldsn_test
+package amqp_test
 
 import (
 	psh "github.com/platformsh/config-reader-go/v2"

--- a/amqp/amqp_test.go
+++ b/amqp/amqp_test.go
@@ -1,0 +1,21 @@
+package sqldsn_test
+
+import (
+	psh "github.com/platformsh/config-reader-go/v2"
+	helper "github.com/platformsh/config-reader-go/v2/testdata"
+	amqp "github.com/platformsh/config-reader-go/v2/amqp"
+	"testing"
+)
+
+func TestAMQPFormatterCalled(t *testing.T){
+	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
+	helper.Ok(t, err)
+
+	credentials, err := config.Credentials("rabbitmq")
+	helper.Ok(t, err)
+
+	formatted, err := amqp.FormattedCredentials(credentials)
+	helper.Ok(t, err)
+
+  helper.Equals(t, "amqp://guest:guest@rabbitmq.internal:5672/", formatted)
+}

--- a/amqp/amqp_test.go
+++ b/amqp/amqp_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestAMQPFormatterCalled(t *testing.T){
+func TestAMQPFormatterCalled(t *testing.T) {
 	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
 	helper.Ok(t, err)
 

--- a/gohelper_test.go
+++ b/gohelper_test.go
@@ -199,10 +199,10 @@ func TestGetNonExistentRouteErrors(t *testing.T) {
 func TestLocalNoRelationships(t *testing.T) {
 	// This should not fail due to the missing relationships.
 	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{
-		"PLATFORM_RELATIONSHIPS":   "",
-		"PLATFORM_VARIABLES":   "",
+		"PLATFORM_RELATIONSHIPS": "",
+		"PLATFORM_VARIABLES":     "",
 		"PLATFORM_APPLICATION":   "",
-		"PLATFORM_ROUTES":   "",
+		"PLATFORM_ROUTES":        "",
 	}), "PLATFORM_")
 	helper.Ok(t, err)
 

--- a/gomemcache/gomemcache.go
+++ b/gomemcache/gomemcache.go
@@ -1,0 +1,12 @@
+package gomemcache
+
+import (
+  "fmt"
+  psh "github.com/platformsh/config-reader-go/v2"
+)
+
+// The gomemcache library requires a specific string to connect to Memcached.
+func FormattedCredentials(creds psh.Credential) (string, error) {
+  formatted := fmt.Sprintf("%s:%d", creds.Host, creds.Port)
+  return formatted, nil
+}

--- a/gomemcache/gomemcache_test.go
+++ b/gomemcache/gomemcache_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestGoMemcacheFormatterCalled(t *testing.T){
+func TestGoMemcacheFormatterCalled(t *testing.T) {
 	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
 	helper.Ok(t, err)
 

--- a/gomemcache/gomemcache_test.go
+++ b/gomemcache/gomemcache_test.go
@@ -1,0 +1,21 @@
+package gomemcache_test
+
+import (
+	psh "github.com/platformsh/config-reader-go/v2"
+	helper "github.com/platformsh/config-reader-go/v2/testdata"
+	mem "github.com/platformsh/config-reader-go/v2/gomemcache"
+	"testing"
+)
+
+func TestGoMemcacheFormatterCalled(t *testing.T){
+	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
+	helper.Ok(t, err)
+
+	credentials, err := config.Credentials("memcached")
+	helper.Ok(t, err)
+
+	formatted, err := mem.FormattedCredentials(credentials)
+	helper.Ok(t, err)
+
+	helper.Equals(t, "memcached.internal:11211", formatted)
+}

--- a/gosolr/gosolr.go
+++ b/gosolr/gosolr.go
@@ -2,24 +2,13 @@ package gosolr
 
 import (
   "fmt"
-  "strings"
   psh "github.com/platformsh/config-reader-go/v2"
 )
 
-type SolrCredentials struct {
-  Url        string
-  Collection string
-}
+// Go-solr requires a string that includes the full collection path to  connect to Solr.
+func FormattedCredentials(creds psh.Credential) (string, error) {
 
-// go-solr requires two separate strings to connect to Solr, a url and a collection name.
-func FormattedCredentials(creds psh.Credential) (SolrCredentials, error) {
-
-  var formatted SolrCredentials
-
-  path := strings.SplitAfter(creds.Path, "/")
-
-  formatted.Url = fmt.Sprintf("http://%s:%d/%s", creds.Host, creds.Port, path[0])
-  formatted.Collection = path[1]
+  formatted := fmt.Sprintf("http://%s:%d/%s", creds.Host, creds.Port, creds.Path)
 
   return formatted, nil
 

--- a/gosolr/gosolr.go
+++ b/gosolr/gosolr.go
@@ -18,7 +18,7 @@ func FormattedCredentials(creds psh.Credential) (SolrCredentials, error) {
 
   path := strings.SplitAfter(creds.Path, "/")
 
-  formatted.Url = fmt.Sprintf("%s:%d/%s", creds.Host, creds.Port, path[0])
+  formatted.Url = fmt.Sprintf("http://%s:%d/%s", creds.Host, creds.Port, path[0])
   formatted.Collection = path[1]
 
   return formatted, nil

--- a/gosolr/gosolr.go
+++ b/gosolr/gosolr.go
@@ -1,0 +1,26 @@
+package gosolr
+
+import (
+  "fmt"
+  "strings"
+  psh "github.com/platformsh/config-reader-go/v2"
+)
+
+type SolrCredentials struct {
+  Url        string
+  Collection string
+}
+
+// go-solr requires two separate strings to connect to Solr, a url and a collection name.
+func FormattedCredentials(creds psh.Credential) (SolrCredentials, error) {
+
+  var formatted SolrCredentials
+
+  path := strings.SplitAfter(creds.Path, "/")
+
+  formatted.Url = fmt.Sprintf("%s:%d/%s", creds.Host, creds.Port, path[0])
+  formatted.Collection = path[1]
+
+  return formatted, nil
+
+}

--- a/gosolr/gosolr_test.go
+++ b/gosolr/gosolr_test.go
@@ -17,6 +17,5 @@ func TestGoSolrFormatterCalled(t *testing.T) {
 	formatted, err := gosolr.FormattedCredentials(credentials)
 	helper.Ok(t, err)
 
-  helper.Equals(t, "http://solr.internal:8080/solr/", formatted.Url)
-  helper.Equals(t, "collection1", formatted.Collection)
+  helper.Equals(t, "http://solr.internal:8080/solr/collection1", formatted)
 }

--- a/gosolr/gosolr_test.go
+++ b/gosolr/gosolr_test.go
@@ -1,0 +1,22 @@
+package gosolr_test
+
+import (
+	psh "github.com/platformsh/config-reader-go/v2"
+	helper "github.com/platformsh/config-reader-go/v2/testdata"
+	gosolr "github.com/platformsh/config-reader-go/v2/gosolr"
+	"testing"
+)
+
+func TestGoSolrFormatterCalled(t *testing.T) {
+	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
+	helper.Ok(t, err)
+
+	credentials, err := config.Credentials("solr")
+	helper.Ok(t, err)
+
+	formatted, err := gosolr.FormattedCredentials(credentials)
+	helper.Ok(t, err)
+
+  helper.Equals(t, "solr.internal:8080/solr/", formatted.Url)
+  helper.Equals(t, "collection1", formatted.Collection)
+}

--- a/gosolr/gosolr_test.go
+++ b/gosolr/gosolr_test.go
@@ -17,6 +17,6 @@ func TestGoSolrFormatterCalled(t *testing.T) {
 	formatted, err := gosolr.FormattedCredentials(credentials)
 	helper.Ok(t, err)
 
-  helper.Equals(t, "solr.internal:8080/solr/", formatted.Url)
+  helper.Equals(t, "http://solr.internal:8080/solr/", formatted.Url)
   helper.Equals(t, "collection1", formatted.Collection)
 }

--- a/libpq/libpq.go
+++ b/libpq/libpq.go
@@ -7,6 +7,6 @@ import (
 
 // lib/pq requires a specfic connection string to connect to PostgreSQL.
 func FormattedCredentials(creds psh.Credential) (string, error) {
-  formatted := fmt.Sprintf("host=%s port=%d user=%s " + "password=%s dbname=%s sslmode=disable", creds.Host, creds.Port, creds.Username, creds.Password, creds.Path)
+  formatted := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", creds.Host, creds.Port, creds.Username, creds.Password, creds.Path)
   return formatted, nil
 }

--- a/libpq/libpq.go
+++ b/libpq/libpq.go
@@ -5,7 +5,7 @@ import (
   psh "github.com/platformsh/config-reader-go/v2"
 )
 
-// lib/pq requires a specfic connection string to connect to PostgreSQL.=
+// lib/pq requires a specfic connection string to connect to PostgreSQL.
 func FormattedCredentials(creds psh.Credential) (string, error) {
   formatted := fmt.Sprintf("host=%s port=%d user=%s " + "password=%s dbname=%s sslmode=disable",
     creds.Host, creds.Port, creds.Username, creds.Password, creds.Path)

--- a/libpq/libpq.go
+++ b/libpq/libpq.go
@@ -1,4 +1,4 @@
-package sqldsn
+package libpq
 
 import (
   "fmt"

--- a/libpq/libpq.go
+++ b/libpq/libpq.go
@@ -7,7 +7,6 @@ import (
 
 // lib/pq requires a specfic connection string to connect to PostgreSQL.
 func FormattedCredentials(creds psh.Credential) (string, error) {
-  formatted := fmt.Sprintf("host=%s port=%d user=%s " + "password=%s dbname=%s sslmode=disable",
-    creds.Host, creds.Port, creds.Username, creds.Password, creds.Path)
+  formatted := fmt.Sprintf("host=%s port=%d user=%s " + "password=%s dbname=%s sslmode=disable", creds.Host, creds.Port, creds.Username, creds.Password, creds.Path)
   return formatted, nil
 }

--- a/libpq/libpq.go
+++ b/libpq/libpq.go
@@ -1,0 +1,13 @@
+package sqldsn
+
+import (
+  "fmt"
+  psh "github.com/platformsh/config-reader-go/v2"
+)
+
+// lib/pq requires a specfic connection string to connect to PostgreSQL.=
+func FormattedCredentials(creds psh.Credential) (string, error) {
+  formatted := fmt.Sprintf("host=%s port=%d user=%s " + "password=%s dbname=%s sslmode=disable",
+    creds.Host, creds.Port, creds.Username, creds.Password, creds.Path)
+  return formatted, nil
+}

--- a/libpq/libpq_test.go
+++ b/libpq/libpq_test.go
@@ -1,0 +1,21 @@
+package libpq_test
+
+import (
+	psh "github.com/platformsh/config-reader-go/v2"
+	helper "github.com/platformsh/config-reader-go/v2/testdata"
+	libpq "github.com/platformsh/config-reader-go/v2/libpq"
+	"testing"
+)
+
+func TestLibPQFormatterCalled(t *testing.T){
+	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
+	helper.Ok(t, err)
+
+	credentials, err := config.Credentials("postgresql")
+	helper.Ok(t, err)
+
+	formatted, err := libpq.FormattedCredentials(credentials)
+	helper.Ok(t, err)
+
+	helper.Equals(t, "host=postgresql.internal port=5432 user=main password=main dbname=main sslmode=disable", formatted)
+}

--- a/libpq/libpq_test.go
+++ b/libpq/libpq_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestLibPQFormatterCalled(t *testing.T){
+func TestLibPQFormatterCalled(t *testing.T) {
 	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
 	helper.Ok(t, err)
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -1,0 +1,13 @@
+package mongo
+
+import (
+  "fmt"
+  psh "github.com/platformsh/config-reader-go/v2"
+)
+
+// The mongo-go-driver requires a specific string to connect to MongoDB.
+func FormattedCredentials(creds psh.Credential) (string, error) {
+  formatted := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
+    creds.Scheme, creds.Username, creds.Password, creds.Host, creds.Port, creds.Path)
+  return formatted, nil
+}

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestLibPQFormatterCalled(t *testing.T){
+func TestMongoDriverFormatterCalled(t *testing.T){
 	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
 	helper.Ok(t, err)
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestMongoDriverFormatterCalled(t *testing.T){
+func TestMongoDriverFormatterCalled(t *testing.T) {
 	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
 	helper.Ok(t, err)
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,0 +1,21 @@
+package mongo_test
+
+import (
+	psh "github.com/platformsh/config-reader-go/v2"
+	helper "github.com/platformsh/config-reader-go/v2/testdata"
+	libpq "github.com/platformsh/config-reader-go/v2/mongo"
+	"testing"
+)
+
+func TestLibPQFormatterCalled(t *testing.T){
+	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
+	helper.Ok(t, err)
+
+	credentials, err := config.Credentials("mongodb")
+	helper.Ok(t, err)
+
+	formatted, err := libpq.FormattedCredentials(credentials)
+	helper.Ok(t, err)
+
+	helper.Equals(t, "mongodb://main:main@mongodb.internal:27017/main", formatted)
+}

--- a/sqldsn/sqldsn_test.go
+++ b/sqldsn/sqldsn_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestSqlDsnFormatterCalled(t *testing.T){
+func TestSqlDsnFormatterCalled(t *testing.T) {
 	config, err := psh.NewRuntimeConfigReal(helper.RuntimeEnv(psh.EnvList{}), "PLATFORM_")
 	helper.Ok(t, err)
 

--- a/testdata/PLATFORM_RELATIONSHIPS.json
+++ b/testdata/PLATFORM_RELATIONSHIPS.json
@@ -38,5 +38,24 @@
          "cluster" : "dtsla3sy7euhc-master-7rqtwti",
          "scheme" : "http"
       }
+   ],
+   "postgresql" : [
+     {
+        "username": "main",
+        "scheme": "pgsql",
+        "service": "postgresql",
+        "ip": "169.254.47.163",
+        "hostname": "ihmuy7beopg6pvps5ib2n6zkvi.postgresql.service._.eu-3.platformsh.site",
+        "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
+        "host": "postgresql.internal",
+        "rel": "postgresql",
+        "path": "main",
+        "query": {
+          "is_master": true
+        },
+        "password": "main",
+        "type": "postgresql:11",
+        "port": 5432
+      }
    ]
 }

--- a/testdata/PLATFORM_RELATIONSHIPS.json
+++ b/testdata/PLATFORM_RELATIONSHIPS.json
@@ -106,5 +106,19 @@
       "type": "memcached:1.4",
       "port": 11211
     }
+  ],
+  "solr": [
+    {
+      "service": "solr",
+      "ip": "169.254.121.53",
+      "hostname": "swhnppdg3ugcd5sktkga73wjoi.solr.service._.eu-3.platformsh.site",
+      "cluster": "rjify4yjcwxaa-master-7rqtwti",
+      "host": "solr.internal",
+      "rel": "solr",
+      "path": "solr\/collection1",
+      "scheme": "solr",
+      "type": "solr:7.6",
+      "port": 8080
+    }
   ]
 }

--- a/testdata/PLATFORM_RELATIONSHIPS.json
+++ b/testdata/PLATFORM_RELATIONSHIPS.json
@@ -93,5 +93,18 @@
       "type": "rabbitmq:3.5",
       "port": 5672
     }
+  ],
+  "memcached": [
+    {
+      "service": "memcached",
+      "ip": "169.254.218.217",
+      "hostname": "pgpd3sdeessilym6p7r3pzrnyi.memcached.service._.eu-3.platformsh.site",
+      "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
+      "host": "memcached.internal",
+      "rel": "memcached",
+      "scheme": "memcached",
+      "type": "memcached:1.4",
+      "port": 11211
+    }
   ]
 }

--- a/testdata/PLATFORM_RELATIONSHIPS.json
+++ b/testdata/PLATFORM_RELATIONSHIPS.json
@@ -1,80 +1,97 @@
 {
-   "database" : [
-      {
-         "scheme" : "mysql",
-         "cluster" : "dtsla3sy7euhc-master-7rqtwti",
-         "service" : "mysql",
-         "username" : "user",
-         "password" : "",
-         "host" : "database.internal",
-         "path" : "main",
-         "public" : false,
-         "fragment" : null,
-         "ip" : "169.254.81.252",
-         "query" : {
-            "is_master" : true
-         },
-         "rel" : "mysql",
-         "type" : "mysql:10.2",
-         "port" : 3306,
-         "hostname" : "ihq65cmi2m7nd3svqpcrbjchyy.mysql.service._.us-2.platformsh.site"
-      }
-   ],
-   "elasticsearch" : [
-      {
-         "hostname" : "bwhgfsnjp7kzqlf7pd35dfg6mm.elasticsearch.service._.us-2.platformsh.site",
-         "port" : 9200,
-         "type" : "elasticsearch:5.4",
-         "rel" : "elasticsearch",
-         "query" : {},
-         "ip" : "169.254.250.214",
-         "path" : null,
-         "public" : false,
-         "fragment" : null,
-         "password" : null,
-         "host" : "elasticsearch.internal",
-         "username" : null,
-         "service" : "elasticsearch",
-         "cluster" : "dtsla3sy7euhc-master-7rqtwti",
-         "scheme" : "http"
-      }
-   ],
-   "postgresql" : [
-     {
-        "username": "main",
-        "scheme": "pgsql",
-        "service": "postgresql",
-        "ip": "169.254.47.163",
-        "hostname": "ihmuy7beopg6pvps5ib2n6zkvi.postgresql.service._.eu-3.platformsh.site",
-        "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
-        "host": "postgresql.internal",
-        "rel": "postgresql",
-        "path": "main",
-        "query": {
-          "is_master": true
-        },
-        "password": "main",
-        "type": "postgresql:11",
-        "port": 5432
-      }
-   ],
-   "mongodb" : [
-     {
-        "username": "main",
-        "scheme": "mongodb",
-        "service": "mongodb",
-        "ip": "169.254.170.222",
-        "hostname": "mzxvzpf4put67tiufvubyji2d4.mongodb.service._.eu-3.platformsh.site",
-        "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
-        "host": "mongodb.internal",
-        "rel": "mongodb",
-        "path": "main",
-        "query": {
-          "is_master": true
-        },
-        "password": "main",
-        "type": "mongodb:3.6",
-        "port": 27017
-      }
-   ]
+  "database": [
+    {
+      "scheme": "mysql",
+      "cluster": "dtsla3sy7euhc-master-7rqtwti",
+      "service": "mysql",
+      "username": "user",
+      "password": "",
+      "host": "database.internal",
+      "path": "main",
+      "public": false,
+      "fragment": null,
+      "ip": "169.254.81.252",
+      "query": {
+        "is_master": true
+      },
+      "rel": "mysql",
+      "type": "mysql:10.2",
+      "port": 3306,
+      "hostname": "ihq65cmi2m7nd3svqpcrbjchyy.mysql.service._.us-2.platformsh.site"
+    }
+  ],
+  "elasticsearch": [
+    {
+      "hostname": "bwhgfsnjp7kzqlf7pd35dfg6mm.elasticsearch.service._.us-2.platformsh.site",
+      "port": 9200,
+      "type": "elasticsearch:5.4",
+      "rel": "elasticsearch",
+      "query": {
+
+      },
+      "ip": "169.254.250.214",
+      "path": null,
+      "public": false,
+      "fragment": null,
+      "password": null,
+      "host": "elasticsearch.internal",
+      "username": null,
+      "service": "elasticsearch",
+      "cluster": "dtsla3sy7euhc-master-7rqtwti",
+      "scheme": "http"
+    }
+  ],
+  "postgresql": [
+    {
+      "username": "main",
+      "scheme": "pgsql",
+      "service": "postgresql",
+      "ip": "169.254.47.163",
+      "hostname": "ihmuy7beopg6pvps5ib2n6zkvi.postgresql.service._.eu-3.platformsh.site",
+      "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
+      "host": "postgresql.internal",
+      "rel": "postgresql",
+      "path": "main",
+      "query": {
+        "is_master": true
+      },
+      "password": "main",
+      "type": "postgresql:11",
+      "port": 5432
+    }
+  ],
+  "mongodb": [
+    {
+      "username": "main",
+      "scheme": "mongodb",
+      "service": "mongodb",
+      "ip": "169.254.170.222",
+      "hostname": "mzxvzpf4put67tiufvubyji2d4.mongodb.service._.eu-3.platformsh.site",
+      "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
+      "host": "mongodb.internal",
+      "rel": "mongodb",
+      "path": "main",
+      "query": {
+        "is_master": true
+      },
+      "password": "main",
+      "type": "mongodb:3.6",
+      "port": 27017
+    }
+  ],
+  "rabbitmq": [
+    {
+      "username": "guest",
+      "scheme": "amqp",
+      "service": "rabbitmq",
+      "ip": "169.254.27.250",
+      "hostname": "sn5meouieccwlvcxdiovijdjnq.rabbitmq.service._.eu-3.platformsh.site",
+      "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
+      "host": "rabbitmq.internal",
+      "rel": "rabbitmq",
+      "password": "guest",
+      "type": "rabbitmq:3.5",
+      "port": 5672
+    }
+  ]
 }

--- a/testdata/PLATFORM_RELATIONSHIPS.json
+++ b/testdata/PLATFORM_RELATIONSHIPS.json
@@ -57,5 +57,24 @@
         "type": "postgresql:11",
         "port": 5432
       }
+   ],
+   "mongodb" : [
+     {
+        "username": "main",
+        "scheme": "mongodb",
+        "service": "mongodb",
+        "ip": "169.254.170.222",
+        "hostname": "mzxvzpf4put67tiufvubyji2d4.mongodb.service._.eu-3.platformsh.site",
+        "cluster": "rjify4yjcwxaa-pr-28-hiclrpi",
+        "host": "mongodb.internal",
+        "rel": "mongodb",
+        "path": "main",
+        "query": {
+          "is_master": true
+        },
+        "password": "main",
+        "type": "mongodb:3.6",
+        "port": 27017
+      }
    ]
 }


### PR DESCRIPTION
Adds formatted credentials packages:

* `amqp` - RabbitMQ library `github.com/streadway/amqp`
* `gomemcache`- Memcached libary `github.com/bradfitz/gomemcache/memcache`
* `libpq` - PostgreSQL library `github.com/lib/pq`
* `mongo` - MongoDB driver library `go.mongodb.org/mongo-driver/mongo`
* `gosolr` - Solr library `github.com/vanng822/go-solr`